### PR TITLE
fix: prevent read error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ dmypy.json
 scratch/
 .DS_Store
 .idea/
+
+/datasets
+/prompt_bank

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cd datasets
 download: https://drive.google.com/drive/folders/1hLFbz0FRxdiDCzgFYtKCOPJYSBVvwW9P
 ```
 
-Download the time sereis prompts 
+Download the time series prompts 
 ```bash
 cd prompt_bank/propmt_data_csv
 download: https://drive.google.com/drive/folders/1hLFbz0FRxdiDCzgFYtKCOPJYSBVvwW9P

--- a/ltsm/data_provider/data_factory.py
+++ b/ltsm/data_provider/data_factory.py
@@ -69,20 +69,20 @@ def create_csv_datasets(
         # Step 2.5 Load prompt for each instance
         # Train Prompt
         train_prompt_data_path = prompt_data_path + '/train'
-        for train_intance_idx in buff:
+        for train_instance_idx in buff:
             instance_prompt =_get_csv_prompt(
                 train_prompt_data_path,  
                 sub_data_path,
-                train_intance_idx
+                train_instance_idx
             )
             train_prompt_data.append(instance_prompt)
         
         val_prompt_data_path = prompt_data_path + '/val'
-        for val_intance_idx in buff:
+        for val_instance_idx in buff:
             instance_prompt = _get_csv_prompt(
                 val_prompt_data_path,  
                 sub_data_path,
-                val_intance_idx
+                val_instance_idx
             )
             val_prompt_data.append(instance_prompt)
         
@@ -167,11 +167,11 @@ def create_csv_test_datasets(
 
     test_prompt_data = []
     test_prompt_data_path = prompt_data_path + "/test"
-    for test_intance_idx in buff:
+    for test_instance_idx in buff:
             instance_prompt = _get_csv_prompt(
                 test_prompt_data_path,  
                 test_data_path,
-                test_intance_idx
+                test_instance_idx
             )
             test_prompt_data.append(instance_prompt)
     test_dataset = TSPromptDataset (
@@ -245,20 +245,20 @@ def create_csv_statprompt_datasets(
         # Step 2.5 Load prompt for each instance
         # Train Prompt
         train_prompt_data_path = prompt_data_path + '/train'
-        for train_intance_idx in buff:
+        for train_instance_idx in buff:
             instance_prompt =_get_csv_prompt(
                 train_prompt_data_path,  
                 sub_data_path,
-                train_intance_idx
+                train_instance_idx
             )
             train_prompt_data.append(instance_prompt)
         
         val_prompt_data_path = prompt_data_path + '/val'
-        for val_intance_idx in buff:
+        for val_instance_idx in buff:
             instance_prompt = _get_csv_prompt(
                 val_prompt_data_path,  
                 sub_data_path,
-                val_intance_idx
+                val_instance_idx
             )
             val_prompt_data.append(instance_prompt)
         
@@ -342,11 +342,11 @@ def create_csv_statprompt_test_datasets(
 
     test_prompt_data = []
     test_prompt_data_path = prompt_data_path + "/test"
-    for test_intance_idx in buff:
+    for test_instance_idx in buff:
             instance_prompt = _get_csv_prompt(
                 test_prompt_data_path,  
                 test_data_path,
-                test_intance_idx
+                test_instance_idx
             )
             test_prompt_data.append(instance_prompt)
             
@@ -591,20 +591,20 @@ def create_csv_token_datasets(
         # Step 2.5 Load prompt for each instance
         # Train Prompt
         train_prompt_data_path = prompt_data_path + '/train'
-        for train_intance_idx in buff:
+        for train_instance_idx in buff:
             instance_prompt =_get_csv_prompt(
                 train_prompt_data_path,  
                 sub_data_path,
-                train_intance_idx
+                train_instance_idx
             )
             train_prompt_data.append(instance_prompt)
         
         val_prompt_data_path = prompt_data_path + '/val'
-        for val_intance_idx in buff:
+        for val_instance_idx in buff:
             instance_prompt = _get_csv_prompt(
                 val_prompt_data_path,  
                 sub_data_path,
-                val_intance_idx
+                val_instance_idx
             )
             val_prompt_data.append(instance_prompt)
         
@@ -688,11 +688,11 @@ def create_csv_token_test_datasets(
 
     test_prompt_data = []
     test_prompt_data_path = prompt_data_path + "/test"
-    for test_intance_idx in buff:
+    for test_instance_idx in buff:
             instance_prompt = _get_csv_prompt(
                 test_prompt_data_path,  
                 test_data_path,
-                test_intance_idx
+                test_instance_idx
             )
             test_prompt_data.append(instance_prompt)
             
@@ -756,11 +756,11 @@ def create_datasets(
         )
 
         # Step 2.5 Load prompt for each instance
-        for intance_idx in buff:
+        for instance_idx in buff:
             instance_prompt = _get_prompt(
                 prompt_data_path,  
                 sub_data_path,
-                intance_idx
+                instance_idx
             )
             prompt_data.append(instance_prompt)
 
@@ -834,11 +834,11 @@ def create_test_datasets(
     )
 
     prompt_data = []
-    for intance_idx in buff:
+    for instance_idx in buff:
             instance_prompt = _get_prompt(
                 prompt_data_path,  
                 test_data_path,
-                intance_idx
+                instance_idx
             )
             prompt_data.append(instance_prompt)
 
@@ -868,6 +868,8 @@ def _get_prompt(prompt_folder_path, data_name, idx_file_name):
 def _get_csv_prompt(prompt_folder_path, data_name, idx_file_name):
     data_path = data_name.split('/')[-2]+'/'+data_name.split('/')[-1].split('.')[0]
     idx_file_name = idx_file_name.replace("/", "-")
+    idx_file_name = idx_file_name.replace("**", "_")
+    idx_file_name = idx_file_name.replace("%", "_")
     
     prompt_path = os.path.join(prompt_folder_path,data_path+'_'+str(idx_file_name)+"_prompt.pth.tar")
     if not os.path.exists(prompt_path):


### PR DESCRIPTION
Encountered a bug where certain prompt files could not be read since downloading and unzipping the Google Drive files changed the names of some prompt files. This led to a zero-dimension concatenation error later.
<img width="646" alt="Code_Lc5NDhmGsH" src="https://github.com/user-attachments/assets/7b6a6db3-c1c2-4203-8251-df9c80f07f91">
<img width="378" alt="Code_NoeQsrUdig" src="https://github.com/user-attachments/assets/5c542088-7ef6-475e-aa18-ff84227bd947">
